### PR TITLE
Full CSS makeover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # temporary
 _tw.js
 forkphorus
+dist
+.cache

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# p3
+## The new packager
+
+This is the new packager for forkphorus & TurboWarp. p3 is a temporary name until something better can be thought of.
+
+### Contributions
+
+Looking for style improvements, so submit a pull!

--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 <head>
   <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Mukta:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
 </head>
 
 <body>
@@ -35,25 +40,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
       <div class="input-div">
         <label>
-          <input name="project.source" type="radio" value="id" checked>
-          Project ID
+          <input name="project.source" type="radio" value="id" class="with-gap" checked>
+          <span>Project ID</span>
         </label>
         <label>
-          <input name="project.source" type="radio" value="file">
-          Project File
+          <input name="project.source" type="radio" value="file" class="with-gap">
+          <span>Project File</span>
         </label>
       </div>
 
       <div if="O.project.source === 'id'">
         <label>
-          Project ID or URL:
+          Project ID or URL
           <input name="project.id" type="text">
         </label>
       </div>
 
       <div if="O.project.source === 'file'">
-        <label>
-          Project File:
+        <label class="waves-effect waves-teal btn-flat">
+          Upload Project
           <input name="project.file" type="file" accept=".sb,.sb2,.sb3">
         </label>
       </div>
@@ -97,15 +102,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
       <div>
         <label>
-          Turbo Mode
-          <input name="forkphorus.playerOptions.turbo" type="checkbox">
+          <input name="forkphorus.playerOptions.turbo" type="checkbox" class="filled-in">
+          <span>Turbo Mode</span>
         </label>
       </div>
       <div>
         <label>
-          Show Controls
           <!-- TODO fix -->
-          <input name="forkphorus.showControls" type="checkbox" checked>
+          <input name="forkphorus.showControls" type="checkbox" checked class="filled-in">
+          <span>Show Controls</span>
         </label>
       </div>
       <div>
@@ -148,8 +153,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       </div>
       <div>
         <label>
-          Sprite Fencing
-          <input name="forkphorus.playerOptions.spriteFencing" type="checkbox">
+          <input name="forkphorus.playerOptions.spriteFencing" type="checkbox" class="filled-in">
+          <span>Sprite Fencing</span>
         </label>
       </div>
     </section>
@@ -158,9 +163,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       <h2>NW.js Options</h2>
 
       <div>
-        <label>
-          Icon
-          <input name="nwjs.icon" type="file" accept=".png">
+        <label class="waves-effect waves-teal btn-flat">
+          Upload Icon
+          <input name="nwjs.icon" type="file" accept=".png"=>
         </label>
       </div>
       <div>
@@ -183,13 +188,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     </section>
 
     <section>
-      <button id="package">Package</button>
+      <button id="package" class="waves-effect waves-light btn">Package</button>
     </section>
   </div>
 
   <section id="downloads">
 
   </section>
+
+  <div id="alert-modal" class="modal">
+    <div class="modal-content">
+      <h4>Error</h4>
+      <p>Invalid project ID.</p>
+    </div>
+    <div class="modal-footer">
+      <a href="#!" class="modal-close waves-effect waves-teal btn-flat">Okay</a>
+    </div>
+  </div>
 
   <script src="lib/jszip.min.js"></script>
   <script src="lib/icns.js"></script>
@@ -198,6 +213,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <script src="packager.js"></script>
 
   <script>
+    M.AutoInit();
     (function() {
       const conditionals = document.querySelectorAll('[if]');
       for (const el of conditionals) {
@@ -302,7 +318,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           addDownloadLink(result.data, result.filename);
         } catch (e) {
           console.error(e);
-          alert(e);
+          var elems = document.querySelectorAll('.modal');
+          var instances = M.Modal.init(elems);
+          var errorMsg = instances[0].el.getElementsByTagName('p');
+          errorMsg[0].innerText = e;
+          instances[0].open();
         }
       });
     }());

--- a/index.html
+++ b/index.html
@@ -18,35 +18,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <style>
-      body {
-        font-family: sans-serif;
-        padding: 2px;
-        max-width: 480px;
-        margin: auto;
-      }
-      @media (prefers-color-scheme: dark) {
-        body {
-          background: #111;
-          color: #ddd;
-        }
-        a {
-          color: #4af;
-        }
-      }
-    </style>
-  </head>
+<head>
+  <link rel="stylesheet" href="./style.css" />
+</head>
 
-  <body>
+<body>
+  <div class="mat-box">
     <h1>The new packager</h1>
 
     <p>This is the new packager for forkphorus & TurboWarp. If anyone has some ideas on how to make this site look pretty, send them on GitHub. p3 is a temporary name until something better can be thought of.</p>
+  </div>
 
+  <div class="mat-box">
     <section>
       <h2>Select project</h2>
 
-      <div>
+      <div class="input-div">
         <label>
           <input name="project.source" type="radio" value="id" checked>
           Project ID
@@ -116,7 +103,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       </div>
       <div>
         <label>
-          Show Controls <!-- TODO fix -->
+          Show Controls
+          <!-- TODO fix -->
           <input name="forkphorus.showControls" type="checkbox" checked>
         </label>
       </div>
@@ -145,7 +133,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       <div>
         <label>
           Loading Screen Text
-          <input name="forkphorus.loadingScreenText" value="forkphorus">
+          <input name="forkphorus.loadingScreenText" type="text" value="forkphorus">
         </label>
       </div>
       <div>
@@ -197,120 +185,129 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <section>
       <button id="package">Package</button>
     </section>
+  </div>
 
-    <section id="downloads">
+  <section id="downloads">
 
-    </section>
+  </section>
 
-    <script src="lib/jszip.min.js"></script>
-    <script src="lib/icns.js"></script>
-    <script src="downloader.js"></script>
-    <script src="parseoptions.js"></script>
-    <script src="packager.js"></script>
+  <script src="lib/jszip.min.js"></script>
+  <script src="lib/icns.js"></script>
+  <script src="downloader.js"></script>
+  <script src="parseoptions.js"></script>
+  <script src="packager.js"></script>
 
-    <script>
-      (function() {
-        const conditionals = document.querySelectorAll('[if]');
+  <script>
+    (function() {
+      const conditionals = document.querySelectorAll('[if]');
+      for (const el of conditionals) {
+        el.visibleIf = new Function('return ' + el.getAttribute('if') + ';');
+      }
+
+      const updateConditionals = () => {
         for (const el of conditionals) {
-          el.visibleIf = new Function('return ' + el.getAttribute('if') + ';');
+          el.hidden = !el.visibleIf();
         }
+      };
 
-        const updateConditionals = () => {
-          for (const el of conditionals) {
-            el.hidden = !el.visibleIf();
-          }
-        };
+      O.onchange = updateConditionals;
+      updateConditionals();
 
-        O.onchange = updateConditionals;
-        updateConditionals();
-  
-        const loadProject = async () => {
-          if (O.project.source === 'file') {
-            if (!O.project.file) {
-              throw new Error('No file selected');
-            }
-            // File is a Blob
-            return new Packager.Project(O.project.file, await SBDownloader.identifyProjectType(O.project.file));
-          } else if (O.project.source === 'id') {
-            const match = O.project.id.match(/\d+/);
-            if (!match) {
-              throw new Error('Invalid project ID');
-            }
-            const project = await SBDownloader.download(match[0]);
-            return new Packager.Project(await project.asBlob(), project.type);
+      const loadProject = async () => {
+        if (O.project.source === 'file') {
+          if (!O.project.file) {
+            throw new Error('No file selected');
           }
-          throw new Error('unknown project source');
-        };
-  
-        const getRuntime = (projectType) => {
-          switch (O.environment.runtime) {
-            case 'turbowarp': return new Packager.runtimes.TurboWarp();
-            case 'forkphorus': return new Packager.runtimes.Forkphorus({
+          // File is a Blob
+          return new Packager.Project(O.project.file, await SBDownloader.identifyProjectType(O.project.file));
+        } else if (O.project.source === 'id') {
+          const match = O.project.id.match(/\d+/);
+          if (!match) {
+            throw new Error('Invalid project ID');
+          }
+          const project = await SBDownloader.download(match[0]);
+          return new Packager.Project(await project.asBlob(), project.type);
+        }
+        throw new Error('unknown project source');
+      };
+
+      const getRuntime = (projectType) => {
+        switch (O.environment.runtime) {
+          case 'turbowarp':
+            return new Packager.runtimes.TurboWarp();
+          case 'forkphorus':
+            return new Packager.runtimes.Forkphorus({
               playerOptions: {
                 ...O.forkphorus.playerOptions,
                 fullscreenMode: 'window',
                 fullscreenPadding: 0,
               },
-              controlsOptions: O.forkphorus.showControls ? { enableFullscreen: false } : null,
+              controlsOptions: O.forkphorus.showControls ? {
+                enableFullscreen: false
+              } : null,
               loadingScreenText: O.forkphorus.loadingScreenText,
               projectType: projectType,
             });
-          }
-          throw new Error('unknown environment');
-        };
-  
-        const getEnvironment = () => {
-          switch (O.environment.target) {
-            case 'html': return new Packager.environments.HTML();
-            case 'zip': return new Packager.environments.Zip();
-            case 'nwjs-win64': return new Packager.environments.NWjs({
+        }
+        throw new Error('unknown environment');
+      };
+
+      const getEnvironment = () => {
+        switch (O.environment.target) {
+          case 'html':
+            return new Packager.environments.HTML();
+          case 'zip':
+            return new Packager.environments.Zip();
+          case 'nwjs-win64':
+            return new Packager.environments.NWjs({
               icon: O.nwjs.icon,
               manifest: O.nwjs.manifest,
               platform: 'windows',
             });
-            case 'nwjs-mac': return new Packager.environments.NWjs({
+          case 'nwjs-mac':
+            return new Packager.environments.NWjs({
               icon: O.nwjs.icon,
               manifest: O.nwjs.manifest,
               platform: 'mac',
             })
-          }
-          throw new Error('unknown environment');
-        };
-  
-        const addDownloadLink = (blob, fileName) => {
-          const link = document.createElement('a');
-          const size = blob.size / 1024 / 1024;
-          link.href = URL.createObjectURL(blob); // TODO: should we delete these after creating them?
-          link.textContent = `Download ${fileName} (${size.toFixed(2)} MiB)`;
-          link.download = fileName;
-          document.querySelector('#downloads').appendChild(link);
-          link.click();
-        };
-  
-        const removeDownloadsLinks = () => {
-          const el = document.querySelector('#downloads');
-          while (el.firstChild) el.removeChild(el.firstChild);
-        };
-  
-        document.getElementById('package').addEventListener('click', async function() {
-          try {
-            removeDownloadsLinks();
-            const runtime = getRuntime();
-            const environment = getEnvironment();
-            const projectData = await loadProject();
-            const result = await environment.package(runtime, projectData);
-            if (!(result.data instanceof Blob)) {
-              result.data = new Blob([result.data]);
-            }
-            addDownloadLink(result.data, result.filename);
-          } catch (e) {
-            console.error(e);
-            alert(e);
-          }
-        });
-      }());
-    </script>
+        }
+        throw new Error('unknown environment');
+      };
 
-  </body>
+      const addDownloadLink = (blob, fileName) => {
+        const link = document.createElement('a');
+        const size = blob.size / 1024 / 1024;
+        link.href = URL.createObjectURL(blob); // TODO: should we delete these after creating them?
+        link.textContent = `Download ${fileName} (${size.toFixed(2)} MiB)`;
+        link.download = fileName;
+        document.querySelector('#downloads').appendChild(link);
+        link.click();
+      };
+
+      const removeDownloadsLinks = () => {
+        const el = document.querySelector('#downloads');
+        while (el.firstChild) el.removeChild(el.firstChild);
+      };
+
+      document.getElementById('package').addEventListener('click', async function() {
+        try {
+          removeDownloadsLinks();
+          const runtime = getRuntime();
+          const environment = getEnvironment();
+          const projectData = await loadProject();
+          const result = await environment.package(runtime, projectData);
+          if (!(result.data instanceof Blob)) {
+            result.data = new Blob([result.data]);
+          }
+          addDownloadLink(result.data, result.filename);
+        } catch (e) {
+          console.error(e);
+          alert(e);
+        }
+      });
+    }());
+  </script>
+
+</body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -5,15 +5,15 @@
   --text: #000;
 }
 
-* {
-  transition: 0.3s;
-}
-
 body {
   text-align: center;
-  font-family: sans-serif;
   background: var(--secondary-bg);
   color: var(--text);
+}
+
+h1, h2 {
+  font-size: 2.3rem !important;
+  margin-top: 1.2rem !important;
 }
 
 input[type='text'] {
@@ -22,6 +22,15 @@ input[type='text'] {
   border-bottom-color: #777;
   border-bottom-width: 0.2em;
   transition: 0.2s;
+  color: var(--text) !important;
+}
+
+input[type='number'], textarea {
+  color: var(--text) !important;
+}
+
+input[type='file'] {
+  display: none;
 }
 
 .input-div {
@@ -32,11 +41,38 @@ input[type='text'] {
   background: var(--primary-bg);
   padding: 1em;
   margin: auto;
+  margin-top: 1em;
   margin-bottom: 1.2em;
   text-align: left;
   max-width: 500px;
   box-shadow: rgba(0, 0, 0, 0.4) 0 0.3em 0.5em;
   border-radius: 0.3em;
+}
+
+.input-div label {
+  margin-right: 1em;
+}
+
+.modal-content, .modal-footer {
+  background: var(--secondary-bg) !important;
+}
+
+.btn-flat {
+  box-shadow: rgba(0, 0, 0, 0.3) 0 0.1em 0.4em !important;
+  color: var(--text) !important;
+}
+
+.caret {
+  fill: var(--text) !important;
+}
+
+.select-wrapper li {
+  background: var(--primary-bg) !important;
+}
+
+.select-wrapper li:hover {
+  transition: 0.2s;
+  background: var(--secondary-bg) !important;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,49 @@
+:root {
+  --primary-accent: #1976d2;
+  --primary-bg: #fff;
+  --secondary-bg: #eee;
+  --text: #000;
+}
+
+* {
+  transition: 0.3s;
+}
+
+body {
+  text-align: center;
+  font-family: sans-serif;
+  background: var(--secondary-bg);
+  color: var(--text);
+}
+
+input[type='text'] {
+  background: transparent;
+  border-color: transparent;
+  border-bottom-color: #777;
+  border-bottom-width: 0.2em;
+  transition: 0.2s;
+}
+
+.input-div {
+  margin-bottom: 1em;
+}
+
+.mat-box {
+  background: var(--primary-bg);
+  padding: 1em;
+  margin: auto;
+  margin-bottom: 1.2em;
+  text-align: left;
+  max-width: 500px;
+  box-shadow: rgba(0, 0, 0, 0.4) 0 0.3em 0.5em;
+  border-radius: 0.3em;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-accent: #1976d2;
+    --primary-bg: #1e1e1e;
+    --secondary-bg: #121212;
+    --text: #fff;
+  }
+}


### PR DESCRIPTION
This PR includes a full CSS makeover.  About half of it is stuff I've written myself and the other half is powered by [Materialize](https://materializecss.com/).  You can view my demo of it [here](https://micahlindley.com/p3).  The full list of improvements: 

- A `README.md` file
- Split CSS and HTML into separate files
- More responsive units (`rem` and `em` instead of `px`)
- Include Materialize CSS
- Include Material Icons
- Hide browser default file selectors
- Replace browser default alerts with Materialize alerts
- Set Roboto as the font

If this PR is approved, I'd appreciate if you'd label this issue as `hacktoberfest-accepted`, as I'm participating in the challenge 😄 