### PR TITLE
Update Electron to 22.3.27 and add ARM support

### DIFF
--- a/electron-bin/generate-windows.js
+++ b/electron-bin/generate-windows.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
 
 const {electronVersion} = require('./version.json');
 
-const newIconPath = path.join(__dirname, '..', 'src', 'packager', 'images', 'default-icon.ico');
+const newIconPath = path.join(__dirname, '../src/packager/images/default-icon.ico');
 
 const download = (arch) => downloadArtifact({
   version: electronVersion,
@@ -19,7 +19,7 @@ const download = (arch) => downloadArtifact({
   arch
 });
 
-const getTempFile = (name) => path.join(__dirname, 'temp', 'windows', name);
+const getTempFile = (name) => path.join(__dirname, 'temp/windows', name);
 
 const extract = async (from, name) => {
   const to = getTempFile(name);
@@ -74,6 +74,7 @@ const run = async (arch) => {
 
 run('ia32')
   .then(() => run('x64'))
+  .then(() => run('arm64'))
   .catch((err) => {
     console.error(err);
     process.exit(1);

--- a/electron-bin/version.json
+++ b/electron-bin/version.json
@@ -1,3 +1,3 @@
 {
-  "electronVersion": "21.2.3"
+  "electronVersion": "22.3.25"
 }

--- a/electron-bin/version.json
+++ b/electron-bin/version.json
@@ -1,3 +1,3 @@
 {
-  "electronVersion": "22.3.25"
+  "electronVersion": "22.3.27"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -464,6 +464,10 @@
       "string": "{type} Windows application (64-bit only, not recommended)",
       "context": "type will become something like 'NW.js' or 'Electron'. Do not translate 'Windows'."
     },
+    "application-win-arm": {
+      "string": "{type} Windows application for ARM",
+      "context": "type will become something like 'NW.js' or 'Electron'. Do not translate 'Windows' or 'ARM'."
+    },
     "application-mac": {
       "string": "{type} macOS application",
       "context": "type will become something like 'NW.js' or 'Electron'. Do not translate 'macOS'."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -472,6 +472,14 @@
       "string": "{type} Linux application (64-bit only)",
       "context": "type will become something like 'NW.js' or 'Electron'. Do not translate 'Linux'."
     },
+    "application-linux-arm32": {
+      "string": "{type} Linux application for ARM (32-bit)",
+      "context": "type will become something like 'NW.js' or 'Electron'. Do not translate 'Linux' or 'ARM'."
+    },
+    "application-linux-arm64": {
+      "string": "{type} Linux application for ARM (64-bit)",
+      "context": "type will become something like 'NW.js' or 'Electron'. Do not translate 'Linux' or 'ARM'."
+    },
     "otherEnvironments": {
       "string": "Other environments (Click to open)",
       "context": "Text that can be clicked to expand list of environments to include some unrecommended ones."

--- a/src/p4/PackagerOptions.svelte
+++ b/src/p4/PackagerOptions.svelte
@@ -91,7 +91,9 @@
     'zip',
     'electron-win32',
     'webview-mac',
-    'electron-linux64'
+    'electron-linux64',
+    'electron-arm32',
+    'electron-arm64'
   ].includes($options.target);
 
   const advancedOptionsInitiallyOpen = (
@@ -836,7 +838,16 @@
           <input type="radio" name="environment" bind:group={$options.target} value="electron-mac">
           {$_('options.application-mac').replace('{type}', 'Electron')}
         </label>
+        <label class="option">
+          <input type="radio" name="environment" bind:group={$options.target} value="electron-linux-arm32">
+          {$_('options.application-linux-arm32').replace('{type}', 'Electron')}
+        </label>
+        <label class="option">
+          <input type="radio" name="environment" bind:group={$options.target} value="electron-linux-arm64">
+          {$_('options.application-linux-arm64').replace('{type}', 'Electron')}
+        </label>  
       </div>
+
       <div class="group">
         <label class="option">
           <input type="radio" name="environment" bind:group={$options.target} value="nwjs-win32">
@@ -935,7 +946,6 @@
             <div>
               <h2>Linux</h2>
               <p>Linux support is still experimental.</p>
-              <p>Linux support in the packager is limited to 64-bit x86 apps (which will run on most desktops and laptops). 32-bit systems and ARM devices such as Raspberry Pis unfortunately are not supported yet.</p>
             </div>
           {/if}
 
@@ -944,14 +954,14 @@
               <h2>Electron</h2>
               <p>The Electron environment works by embedding a copy of Chromium (the open source part of Google Chrome) along with your project, which means the app will be very large.</p>
 
-              {#if $options.target.includes('mac')}
+              {#if $options.target.includes('win')}
+                {#if $options.target.includes('32')}
+                  <p>Note: You have selected the 32-bit or 64-bit mode. This maximizes device compatibility but limits the amount of memory the app can use. If you encounter crashes, try going into "Other environments" and using the 64-bit only mode instead.</p>
+                {/if}
+              {:else if $options.target.includes('mac')}
                 <p>On macOS, the app will run natively on both Intel Silicon and Apple Silicon Macs.</p>
               {:else if $options.target.includes('linux')}
                 <p>On Linux, the application can be started by running <code>start.sh</code></p>
-              {/if}
-
-              {#if $options.target.includes('32')}
-                <p>Note: You have selected the 32-bit or 64-bit mode. This maximizes device compatibility but limits the amount of memory the app can use. If you encounter crashes, try going into "Other environments" and using the 64-bit only mode instead.</p>
               {/if}
             </div>
           {:else if $options.target.includes('nwjs')}

--- a/src/p4/PackagerOptions.svelte
+++ b/src/p4/PackagerOptions.svelte
@@ -91,9 +91,7 @@
     'zip',
     'electron-win32',
     'webview-mac',
-    'electron-linux64',
-    'electron-arm32',
-    'electron-arm64'
+    'electron-linux64'
   ].includes($options.target);
 
   const advancedOptionsInitiallyOpen = (

--- a/src/p4/PackagerOptions.svelte
+++ b/src/p4/PackagerOptions.svelte
@@ -835,6 +835,10 @@
           {$_('options.application-win64').replace('{type}', 'Electron')}
         </label>
         <label class="option">
+          <input type="radio" name="environment" bind:group={$options.target} value="electron-win-arm">
+          {$_('options.application-win-arm').replace('{type}', 'Electron')}
+        </label>
+        <label class="option">
           <input type="radio" name="environment" bind:group={$options.target} value="electron-mac">
           {$_('options.application-mac').replace('{type}', 'Electron')}
         </label>

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -42,24 +42,24 @@ export default {
     estimatedSize: 153808583
   },
   'electron-win32': {
-    src: externalFile('electron-v21.2.3-win32-ia32.zip'),
-    sha256: 'ee813a8dc4050c7d3a3cc80233bf5f4ddd0483e1c934eb69d735a3b3563ce3bf',
-    estimatedSize: 89317110
+    src: externalFile('electron-v22.3.25-win32-ia32.zip'),
+    sha256: 'a0fa8192e8d33f8876bb3867bf58f72fdafb1d106a68eab3b04aef0fed91fb4a',
+    estimatedSize: 90856612
   },
   'electron-win64': {
-    src: externalFile('electron-v21.2.3-win32-x64.zip'),
-    sha256: 'b1695f0528567ecc1f7e667520c7770321df35d058841e24c4e9793f4e43e56a',
-    estimatedSize: 95073928
+    src: externalFile('electron-v22.3.25-win32-x64.zip'),
+    sha256: '2b77e0ef8974517b6add666630f8c425adec1861402099da0f9a63abb6c0721b',
+    estimatedSize: 96605498
   },
   'electron-mac': {
-    src: externalFile('electron-v21.0.1-macos-universal.zip'),
-    sha256: 'c31d1ef26f7b6230881a11308ebf8f4487a1a3fb7a151da0972fad77bc9e6acf',
-    estimatedSize: 154789837
+    src: externalFile('electron-v22.3.25-macos-universal.zip'),
+    sha256: '12febebaf468f48a9ce5d7f6a516e79c3a10b84b7eadb375eeb91320a8023acc',
+    estimatedSize: 160584431
   },
   'electron-linux64': {
-    src: externalFile('electron-v21.0.1-linux-x64.zip'),
-    sha256: '4fd6d7b5a65f44a43165ae77d0484db992b30d6efba478a192e984506fbd52b6',
-    estimatedSize: 90635371
+    src: externalFile('electron-v22.3.25-linux-x64.zip'),
+    sha256: 'f1d0f66b13d5b7b9e3f7d9b22891bf0b5b6f87e45c46054cd3fa74636c19e921',
+    estimatedSize: 93426892
   },
   'webview-mac': {
     src: externalFile('WebView-macos-5.zip'),

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -22,24 +22,24 @@ const relativeScaffolding = (name) => `scaffolding/${name}`;
 
 export default {
   'nwjs-win64': {
-    src: externalFile('nwjs-v0.80.0-win-x64.zip'),
-    sha256: '447492c16573684f58656e6418d0794cea5e3c111fa2680bf2b4f2307d79eb91',
-    estimatedSize: 133532391
+    src: externalFile('nwjs-v0.68.1-win-x64.zip'),
+    sha256: '82527d29f060bad7ec041f7c0536b1376f8bad5e5584adf7e3cf7205755a106c',
+    estimatedSize: 119821598
   },
   'nwjs-win32': {
-    src: externalFile('nwjs-v0.80.0-win-ia32.zip'),
-    sha256: '641eeffe2b77cefe9b9636ec042285c7905d453f56aedaa55adde0e3f630e0a7',
-    estimatedSize: 124391320
+    src: externalFile('nwjs-v0.68.1-win-ia32.zip'),
+    sha256: '7dd3104c2726082a8acd8973af2b2b223bc97960b722ec141b9bf07d84a0281b',
+    estimatedSize: 112613344
   },
   'nwjs-mac': {
-    src: externalFile('nwjs-v0.80.0-osx-x64.zip'),
-    sha256: '9c3170f03f63f97b2739e7e03140b1742fc52b3e5c91ec7d000e71bd83a43329',
-    estimatedSize: 120496868
+    src: externalFile('nwjs-v0.68.1-osx-x64.zip'),
+    sha256: '4b1356302738a45f7ee212f6ecb997eb5d31403bfc45a7dd58429c968a1f581a',
+    estimatedSize: 119091132
   },
   'nwjs-linux-x64': {
-    src: externalFile('nwjs-v0.80.0-linux-x64.zip'),
-    sha256: 'b10571ed0ef776006d037a0d183dc51b1ece20a629d25d9119162c0c30863526',
-    estimatedSize: 153808583
+    src: externalFile('nwjs-v0.68.1-linux-x64.zip'),
+    sha256: '5f597add1a2b6f13592117cc955111cea8211c13b21165e29c6616f385df5b94',
+    estimatedSize: 135854818
   },
   'electron-win32': {
     src: externalFile('electron-v22.3.27-win32-ia32.zip'),

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -38,7 +38,7 @@ export default {
   },
   'nwjs-linux-x64': {
     src: externalFile('nwjs-v0.80.0-linux-x64.zip'),
-    sha256: 'fa4fb50b9fcf4cb357e61a6c5454b525ca042d9081a9bc0829a113582d29c9f0',
+    sha256: 'b10571ed0ef776006d037a0d183dc51b1ece20a629d25d9119162c0c30863526',
     estimatedSize: 153808583
   },
   'electron-win32': {

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -42,33 +42,33 @@ export default {
     estimatedSize: 153808583
   },
   'electron-win32': {
-    src: externalFile('electron-v22.3.25-win32-ia32.zip'),
-    sha256: 'a0fa8192e8d33f8876bb3867bf58f72fdafb1d106a68eab3b04aef0fed91fb4a',
+    src: externalFile('electron-v22.3.27-win32-ia32.zip'),
+    sha256: '47bd498e5513529c5e141394fc9fd610cba1dcdea9e6dbb165edf929cbfd9af2',
     estimatedSize: 90856612
   },
   'electron-win64': {
-    src: externalFile('electron-v22.3.25-win32-x64.zip'),
-    sha256: '2b77e0ef8974517b6add666630f8c425adec1861402099da0f9a63abb6c0721b',
+    src: externalFile('electron-v22.3.27-win32-x64.zip'),
+    sha256: '1a02c0f7af9664696f790dcce05948f0458a2f4f2d48c685f911d2eb99a4c9da',
     estimatedSize: 96605498
   },
   'electron-mac': {
-    src: externalFile('electron-v22.3.25-macos-universal.zip'),
-    sha256: '948a2e195add755c366bd759ebd6c0521d7f34936edd9c353bc9148e8380d8b4',
+    src: externalFile('electron-v22.3.27-macos-universal.zip'),
+    sha256: '598b35f9030fe30f81b4041be048cd0374f675bd1bc0f172c26cf2808e80a3d9',
     estimatedSize: 160882083
   },
   'electron-linux64': {
-    src: externalFile('electron-v22.3.25-linux-x64.zip'),
-    sha256: 'f1d0f66b13d5b7b9e3f7d9b22891bf0b5b6f87e45c46054cd3fa74636c19e921',
+    src: externalFile('electron-v22.3.27-linux-x64.zip'),
+    sha256: '631d8eb08098c48ce2b29421e74c69ac0312b1e42f445d8a805414ba1242bf3a',
     estimatedSize: 93426892
   },
   'electron-linux-arm32': {
-    src: externalFile('electron-v22.3.25-linux-armv7l.zip'),
-    sha256: 'd90184e22f9d57fa4f207d5e5006bbfb6df1b9e10760333c3f72353ffa5ef3d1',
+    src: externalFile('electron-v22.3.27-linux-armv7l.zip'),
+    sha256: '9f8372606e5ede83cf1c73a3d8ff07047e4e3ef614aa89a76cd497dc06cf119d',
     estimatedSize: 82722572
   },
   'electron-linux-arm64': {
-    src: externalFile('electron-v22.3.25-linux-arm64.zip'),
-    sha256: '08c4e127d06d73ad91fa308c811ace9d4f8607fe15ba0b2694261d32a2127a8c',
+    src: externalFile('electron-v22.3.27-linux-arm64.zip'),
+    sha256: '60279395a5ce4eaf3c08f1e717771b203830902d3fe3a7c311bc37deb1a0e15e',
     estimatedSize: 93932512
   },
   'webview-mac': {

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -51,6 +51,11 @@ export default {
     sha256: '1a02c0f7af9664696f790dcce05948f0458a2f4f2d48c685f911d2eb99a4c9da',
     estimatedSize: 96605498
   },
+  'electron-win-arm': {
+    src: externalFile('electron-v22.3.27-win32-arm64.zip'),
+    sha256: '0e4ad218018c0881ef4de363107a94dd2ced40367a0e18ca7d0dde1f40da0531',
+    estimatedSize: 94065344
+  },
   'electron-mac': {
     src: externalFile('electron-v22.3.27-macos-universal.zip'),
     sha256: '598b35f9030fe30f81b4041be048cd0374f675bd1bc0f172c26cf2808e80a3d9',

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -61,6 +61,16 @@ export default {
     sha256: 'f1d0f66b13d5b7b9e3f7d9b22891bf0b5b6f87e45c46054cd3fa74636c19e921',
     estimatedSize: 93426892
   },
+  'electron-linux-arm32': {
+    src: externalFile('electron-v22.3.25-linux-armv7l.zip'),
+    sha256: 'd90184e22f9d57fa4f207d5e5006bbfb6df1b9e10760333c3f72353ffa5ef3d1',
+    estimatedSize: 82722572
+  },
+  'electron-linux-arm64': {
+    src: externalFile('electron-v22.3.25-linux-arm64.zip'),
+    sha256: '08c4e127d06d73ad91fa308c811ace9d4f8607fe15ba0b2694261d32a2127a8c',
+    estimatedSize: 93932512
+  },
   'webview-mac': {
     src: externalFile('WebView-macos-5.zip'),
     sha256: 'b5636571cd9be2aae2f6dac1ab090fdf829c8fdfe91f462cc2feb2d324705f9f',

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -53,8 +53,8 @@ export default {
   },
   'electron-mac': {
     src: externalFile('electron-v22.3.25-macos-universal.zip'),
-    sha256: '12febebaf468f48a9ce5d7f6a516e79c3a10b84b7eadb375eeb91320a8023acc',
-    estimatedSize: 160584431
+    sha256: '948a2e195add755c366bd759ebd6c0521d7f34936edd9c353bc9148e8380d8b4',
+    estimatedSize: 160882083
   },
   'electron-linux64': {
     src: externalFile('electron-v22.3.25-linux-x64.zip'),

--- a/src/packager/large-assets.js
+++ b/src/packager/large-assets.js
@@ -22,24 +22,24 @@ const relativeScaffolding = (name) => `scaffolding/${name}`;
 
 export default {
   'nwjs-win64': {
-    src: externalFile('nwjs-v0.68.1-win-x64.zip'),
-    sha256: '82527d29f060bad7ec041f7c0536b1376f8bad5e5584adf7e3cf7205755a106c',
-    estimatedSize: 119821598
+    src: externalFile('nwjs-v0.80.0-win-x64.zip'),
+    sha256: '447492c16573684f58656e6418d0794cea5e3c111fa2680bf2b4f2307d79eb91',
+    estimatedSize: 133532391
   },
   'nwjs-win32': {
-    src: externalFile('nwjs-v0.68.1-win-ia32.zip'),
-    sha256: '7dd3104c2726082a8acd8973af2b2b223bc97960b722ec141b9bf07d84a0281b',
-    estimatedSize: 112613344
+    src: externalFile('nwjs-v0.80.0-win-ia32.zip'),
+    sha256: '641eeffe2b77cefe9b9636ec042285c7905d453f56aedaa55adde0e3f630e0a7',
+    estimatedSize: 124391320
   },
   'nwjs-mac': {
-    src: externalFile('nwjs-v0.68.1-osx-x64.zip'),
-    sha256: '4b1356302738a45f7ee212f6ecb997eb5d31403bfc45a7dd58429c968a1f581a',
-    estimatedSize: 119091132
+    src: externalFile('nwjs-v0.80.0-osx-x64.zip'),
+    sha256: '9c3170f03f63f97b2739e7e03140b1742fc52b3e5c91ec7d000e71bd83a43329',
+    estimatedSize: 120496868
   },
   'nwjs-linux-x64': {
-    src: externalFile('nwjs-v0.68.1-linux-x64.zip'),
-    sha256: '5f597add1a2b6f13592117cc955111cea8211c13b21165e29c6616f385df5b94',
-    estimatedSize: 135854818
+    src: externalFile('nwjs-v0.80.0-linux-x64.zip'),
+    sha256: 'fa4fb50b9fcf4cb357e61a6c5454b525ca042d9081a9bc0829a113582d29c9f0',
+    estimatedSize: 153808583
   },
   'electron-win32': {
     src: externalFile('electron-v21.2.3-win32-ia32.zip'),


### PR DESCRIPTION
 - Updated Electron to 22.3.27, not going further yet due to Windows 7/8/8.1 support being dropped in later versions
 - Added ARM support for Windows, 32-bit Linux, 64-bit Linux
