### PR TITLE
Update to new compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12542,7 +12542,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "2.1.46",
-      "resolved": "git+ssh://git@github.com/TurboWarp/scratch-vm.git#37c6fbe63ba6f3f930d2dfcaf03adb4ce9dbd1e9",
+      "resolved": "git+ssh://git@github.com/TurboWarp/scratch-vm.git#bf7ae82d7584c42e6d3ab43446e9bae641790d39",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12542,8 +12542,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "2.1.46",
-      "resolved": "git+ssh://git@github.com/TurboWarp/scratch-vm.git#6222be2a3c1e1fe22add331685a4f5b746eec969",
-      "integrity": "sha512-kWs8cVHmpf1B7/JeuwO1ptqiEwQveSss2DlAaM8pc8DKx/POUI+sbFO0bAdZFbVNmwFC5ozGt8eGB5slfS+nQw==",
+      "resolved": "git+ssh://git@github.com/TurboWarp/scratch-vm.git#37c6fbe63ba6f3f930d2dfcaf03adb4ce9dbd1e9",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/src/p4/News.svelte
+++ b/src/p4/News.svelte
@@ -17,10 +17,12 @@
   <div lang="en">
     <p>
       <span class="badge">New!</span>
-      We've updated the packager to use the <a href="https://docs.turbowarp.org/new-compiler">new compiler</a>.
     </p>
     <p>
-      If you need the old compiler still, you can access it on <a href="https://packager-legacy.turbowarp.org/">packager-legacy.turbowarp.org</a>.
+      We've updated the packager to use the <a href="https://docs.turbowarp.org/new-compiler">new compiler</a> to make projects run even faster.
+    </p>
+    <p>
+      If your project relies on extensions that require the old compiler, a version of the packager using the old compiler will be available on <a href="https://packager-legacy.turbowarp.org/">packager-legacy.turbowarp.org</a> indefinitely.
     </p>
   </div>
 </Section>

--- a/src/p4/News.svelte
+++ b/src/p4/News.svelte
@@ -1,4 +1,3 @@
-<!--
 <script>
   import Section from './Section.svelte';
   const color = '#b117f8';
@@ -16,6 +15,12 @@
 
 <Section accent={color}>
   <div lang="en">
+    <p>
+      <span class="badge">New!</span>
+      We've updated the packager to use the <a href="https://docs.turbowarp.org/new-compiler">new compiler</a>.
+    </p>
+    <p>
+      If you need the old compiler still, you can access it on <a href="https://packager-legacy.turbowarp.org/">packager-legacy.turbowarp.org</a>.
+    </p>
   </div>
 </Section>
--->


### PR DESCRIPTION
Ignore dependabot's scratch-vm bump pull requests for a bit. This is the one we'll merge since we want to announce this to users simultaneously. Drafted because waiting until about 1 week of no new regressions found in the new compiler.